### PR TITLE
add ZoraLzMintActionV1 action module

### DIFF
--- a/open-actions.json
+++ b/open-actions.json
@@ -64,5 +64,11 @@
     "address": "0x50f1D8779078c790b82dE5Aa8d72A841e1CBBbE1",
     "requiresUserFunds": true,
     "blockExplorerLink": "https://polygonscan.com/address/0x50f1D8779078c790b82dE5Aa8d72A841e1CBBbE1#code"
+  },
+  {
+    "name": "ZoraLzMintActionV1",
+    "address": "0xe51f055aBf11Aba71e8ff06c70cdc17c3B5FE354",
+    "requiresUserFunds": true,
+    "blockExplorerLink": "https://polygonscan.com/address/0xe51f055aBf11Aba71e8ff06c70cdc17c3B5FE354#code"
   }
 ]

--- a/open-actions.json
+++ b/open-actions.json
@@ -67,8 +67,8 @@
   },
   {
     "name": "ZoraLzMintActionV1",
-    "address": "0xe51f055aBf11Aba71e8ff06c70cdc17c3B5FE354",
+    "address": "0x5f377e3e9BE56Ff72588323Df6a4ecd5cEedc56A",
     "requiresUserFunds": true,
-    "blockExplorerLink": "https://polygonscan.com/address/0xe51f055aBf11Aba71e8ff06c70cdc17c3B5FE354#code"
+    "blockExplorerLink": "https://polygonscan.com/address/0x5f377e3e9BE56Ff72588323Df6a4ecd5cEedc56A#code"
   }
 ]


### PR DESCRIPTION
# Verify my module

- Module type: open action
- Module name: `ZoraLzMintActionV1`
- Module address: `0x5f377e3e9BE56Ff72588323Df6a4ecd5cEedc56A`
- My module is immutable: yes (with `ownerOnly` functions to config fees, gas, remotes)
- My module is using an upgradeable proxy: no
- My module has been registered on the registry: yes
- My module has been verified on the block explorer: yes
- My module is a paid action so uses currencies: yes
- Summary of my module: allows anyone to promote their Zora NFTs from any Zora-supported chain, allowing mints on polygon with any whitelisted currency. relay done via LayerZero, swaps with Uniswap.
- I have updated the module type json file: yes
