### PR TITLE
add decent oa

### DIFF
--- a/open-actions.json
+++ b/open-actions.json
@@ -70,5 +70,11 @@
     "address": "0x5f377e3e9BE56Ff72588323Df6a4ecd5cEedc56A",
     "requiresUserFunds": true,
     "blockExplorerLink": "https://polygonscan.com/address/0x5f377e3e9BE56Ff72588323Df6a4ecd5cEedc56A#code"
+  },
+  {
+    "name": "DecentOpenAction",
+    "address": "0xA9d72bCAd216b1F05d7D60b46Fd8dC01D501257a",
+    "requiresUserFunds": true,
+    "blockExplorerLink": "https://polygonscan.com/address/0xA9d72bCAd216b1F05d7D60b46Fd8dC01D501257a#code"
   }
 ]


### PR DESCRIPTION
# Verify my module

- Module type: open action
- Module name: DecentOpenAction
- Module address: 0xA9d72bCAd216b1F05d7D60b46Fd8dC01D501257a
- My module is immutable: no
- My module is using an upgradeable proxy: no
- My module has been registered on the registry: yes
- My module has been verified on the block explorer: yes
- My module is a paid action so uses currencies: yes
- Summary of my module: decent open action allows users to call any same chain and cross-chain tx (i.e. place a bet on polymarket, tip user in eth on arbitrum, mint an nft on zora chain). We call the `CoreWrapper` contract from the `DecentOpenAction` contract. From here, we initialize our action w the relevant data. And for a user to call processPublicationAction, they can fetch the data stored in initialize action, pass in those inputs to the decent api, + take the returned calldata to call processPublicationAction. The function calls either swapAndExecute or bridgeAndExecute, depending on the chainId
- I have updated the module type json file: yes
