### PR TITLE
Add Orna TipActionModule

### DIFF
--- a/open-actions.json
+++ b/open-actions.json
@@ -82,5 +82,11 @@
     "address": "0x410688fc60028c805bdf8592a6504a0096927911",
     "requiresUserFunds": true,
     "blockExplorerLink": "https://polygonscan.com/address/0x410688fc60028c805bdf8592a6504a0096927911#code"
+  },
+  {
+    "name": "TipActionModule",
+    "address": "0x22cb67432C101a9b6fE0F9ab542c8ADD5DD48153",
+    "requiresUserFunds": true,
+    "blockExplorerLink": "https://polygonscan.com/address/0x22cb67432C101a9b6fE0F9ab542c8ADD5DD48153#code"
   }
 ]


### PR DESCRIPTION
# Verify my module

- Module type: [open action]
- Module name: TipActionModule
- Module address: 0x22cb67432C101a9b6fE0F9ab542c8ADD5DD48153
- My module is immutable: [yes]
- My module is using an upgradeable proxy: [no]
- My module has been registered on the registry: [yes]
- My module has been verified on the block explorer: [yes]
- My module is a paid action so uses currencies: [yes ]
- Summary of my module: To tip post creators on Lens via Lens approved currencies
- I have updated the module type json file: [yes]

Viktar Naumik from Avara already reviewed it and we applied his points

Source code and more info [https://github.com/mvanhalen/TipActionModule](https://github.com/mvanhalen/TipActionModule)
