### PR TITLE
add RewardEngagement action module

### DIFF
--- a/open-actions.json
+++ b/open-actions.json
@@ -88,5 +88,11 @@
     "address": "0x22cb67432C101a9b6fE0F9ab542c8ADD5DD48153",
     "requiresUserFunds": true,
     "blockExplorerLink": "https://polygonscan.com/address/0x22cb67432C101a9b6fE0F9ab542c8ADD5DD48153#code"
+  },
+  {
+    "name": "RewardEngagementAction",
+    "address": "0xDA7F4679312Ab7Dc9B4A985564a391c14Ef45A72",
+    "requiresUserFunds": false,
+    "blockExplorerLink": "https://polygonscan.com/address/0xDA7F4679312Ab7Dc9B4A985564a391c14Ef45A72#code"
   }
 ]


### PR DESCRIPTION
# Verify my module

- Module type: open action
- Module name: `RewardEngagementAction`
- Module address: `0xDA7F4679312Ab7Dc9B4A985564a391c14Ef45A72`
- My module is immutable: yes
- My module is using an upgradeable proxy: no
- My module has been registered on the registry: yes
- My module has been verified on the block explorer: yes
- My module is a paid action so uses currencies: no
- Summary of my module: Allows creators to reward their most engaged followers by giving out points on their badge NFT for comments/mirrors/quotes
- I have updated the module type json file: yes
