### PR TITLE
Updated contract to fix metadata

### DIFF
--- a/open-actions.json
+++ b/open-actions.json
@@ -115,8 +115,8 @@
   },
   {
     "name": "AuctionCollectAction",
-    "address": "0x6511B9CE24E1198F4803e652B58ABB687484A6d0",
+    "address": "0x516E3E57A3d1c9E2Db09Cd8eC0C54309b6cD1c00",
     "requiresUserFunds": true,
-    "blockExplorerLink": "https://polygonscan.com/address/0x6511B9CE24E1198F4803e652B58ABB687484A6d0#code"
+    "blockExplorerLink": "https://polygonscan.com/address/0x516E3E57A3d1c9E2Db09Cd8eC0C54309b6cD1c00#code"
   }
 ]


### PR DESCRIPTION
# Update my module

Because of an indexing issue with OpenSea we had to make a small change to the CustomCollectNFT.sol which you can see here https://github.com/mvanhalen/scaffold-lens-auction/commit/63d7cb6f6533a3023c6743a0ab7d5fb18ef926f6

Here is the new contract [https://polygonscan.com/address/0x516E3E57A3d1c9E2Db09Cd8eC0C54309b6cD1c00](https://polygonscan.com/address/0x516E3E57A3d1c9E2Db09Cd8eC0C54309b6cD1c00)

Here a bid transaction with that contract [https://polygonscan.com/tx/0x1ddfa8f4b5d3d1068fa6dd4286f6b91f550bd9225aaf744f10daddf3aea1fedb](https://polygonscan.com/tx/0x1ddfa8f4b5d3d1068fa6dd4286f6b91f550bd9225aaf744f10daddf3aea1fedb)

Indexed asset https://opensea.io/assets/matic/0x392f35352b2556056bd27fd716773dd020fe3cb8/1

Apologies for the extra work. But all good now. Ready for auctions!

