### PR TITLE
Updates AuctionCollectAction address (again)

### DIFF
--- a/open-actions.json
+++ b/open-actions.json
@@ -115,8 +115,8 @@
   },
   {
     "name": "AuctionCollectAction",
-    "address": "0x516E3E57A3d1c9E2Db09Cd8eC0C54309b6cD1c00",
+    "address": "0x857b5e09d54AD26580297C02e4596537a2d3E329",
     "requiresUserFunds": true,
-    "blockExplorerLink": "https://polygonscan.com/address/0x516E3E57A3d1c9E2Db09Cd8eC0C54309b6cD1c00#code"
+    "blockExplorerLink": "https://polygonscan.com/address/0x857b5e09d54AD26580297C02e4596537a2d3E329#code"
   }
 ]


### PR DESCRIPTION
There was an issue preventing tokens from being returned when out-bid.

Here's the change commit, which includes a new unit test to ensure funds are returned: https://github.com/mvanhalen/scaffold-lens-auction/commit/00bf8609667d57223299655a6bd3d61715138379

Here's a transaction showing a bid being replaced when out-bid: https://polygonscan.com/tx/0xdd7bdefedb0c17c11dd5734c22c3567c6fbd161a4550c91029c8f29d4a00b051