### PR TITLE
New AuctionCollectAction address - Fix returns bids to executor

### DIFF
--- a/open-actions.json
+++ b/open-actions.json
@@ -115,9 +115,9 @@
   },
   {
     "name": "AuctionCollectAction",
-    "address": "0x857b5e09d54AD26580297C02e4596537a2d3E329",
+    "address": "0x57bCA94DD71A03Fb2A10Bb6aC64e151AA102ff62",
     "requiresUserFunds": true,
-    "blockExplorerLink": "https://polygonscan.com/address/0x857b5e09d54AD26580297C02e4596537a2d3E329#code"
+    "blockExplorerLink": "https://polygonscan.com/address/0x57bCA94DD71A03Fb2A10Bb6aC64e151AA102ff62#code"
   },
   {
     "name": "ScoreOpenAction",


### PR DESCRIPTION
# Verify my module

- Module type: open action
- Module name: AuctionCollectAction
- Module address: 0x57bCA94DD71A03Fb2A10Bb6aC64e151AA102ff62
- My module is immutable: no
- My module is using an upgradeable proxy: no
- My module has been registered on the registry: yes
- My module has been verified on the block explorer: yes
- My module is a paid action so uses currencies: yes
- Transaction hash of a successful `act` or `actWithSig` on Lens Testnet (Amoy) contracts: 0x30bfd8260b4c773a4f2b018c94c1d26b3a7eacca81245d6e4c69ecf974690cc0
- Summary of my module: English auctions for 1 of 1 Lens Collects
- I have updated the module type json file: yes

The Smart Auctions contract has been updated to change the address that bids are returned to when outbid. Previously they would be returned to the profile owner. The new contract always returns bids to the transaction executor.

Context for change: https://hey.xyz/posts/0x01a14e-0x047d-DA-49e9c057

New repository for Smart Auctions: https://github.com/iPaulPro/lens-smart-auctions

Commit with change: https://github.com/iPaulPro/lens-smart-auctions/commit/0777eefd3787c6853d6cf09db5b85d5d1483cc24

Updated unit tests: https://github.com/iPaulPro/lens-smart-auctions/blob/main/packages/AuctionCollectAction/test/AuctionCollectAction.ts