### PR TITLE
Use actions/checkout@v3 (Latest Stable Version)

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Use Node.js
         uses: actions/setup-node@v2


### PR DESCRIPTION
You are using actions/checkout@v2, but the latest stable version is v3. It's always a good idea to use the latest version for improved performance, security, and bug fixes.

# Verify my module

- Module type: [open action | follow | reference]
- Module name: <enter module name>
- Module address: <enter module address>
- My module is immutable: [yes | no]
- My module is using an upgradeable proxy: [yes | no]
- My module has been registered on the registry: [yes | no]
- My module has been verified on the block explorer: [yes | no]
- My module is a paid action so uses currencies: [yes | no]
- Transaction hash of a successful `act` or `actWithSig` on Lens Testnet (Mumbai) contracts: <insert tx hash here>
- Summary of my module: <enter summary of module>
- I have updated the module type json file: [yes | no]
